### PR TITLE
Add support for trimming a prefix from enum types

### DIFF
--- a/stringer.go
+++ b/stringer.go
@@ -87,6 +87,7 @@ var (
 	yaml            = flag.Bool("yaml", false, "if true, yaml marshaling methods will be generated. Default: false")
 	output          = flag.String("output", "", "output file name; default srcdir/<type>_string.go")
 	transformMethod = flag.String("transform", "noop", "enum item name transformation method. Default: noop")
+	trimPrefix      = flag.String("trimPrefix", "", "trim this prefix from enum names before transformation. Default: ''")
 )
 
 // Usage is a replacement usage function for the flags package.
@@ -149,7 +150,7 @@ func main() {
 
 	// Run generate for each type.
 	for _, typeName := range types {
-		g.generate(typeName, *json, *yaml, *sql, *transformMethod)
+		g.generate(typeName, *json, *yaml, *sql, *transformMethod, *trimPrefix)
 	}
 
 	// Format the output.
@@ -284,7 +285,7 @@ func (pkg *Package) check(fs *token.FileSet, astFiles []*ast.File) {
 	pkg.typesPkg = typesPkg
 }
 
-func (g *Generator) transformValueNames(values []Value, transformMethod string) {
+func (g *Generator) transformValueNames(values []Value, transformMethod, trimPrefix string) {
 	var transform func(string) string
 	switch transformMethod {
 	case "snake":
@@ -292,16 +293,20 @@ func (g *Generator) transformValueNames(values []Value, transformMethod string) 
 	case "kebab":
 		transform = toKebabCase
 	default:
-		return
+		if trimPrefix == "" {
+			return
+		}
+		transform = func(s string) string { return s }
 	}
 
-	for i := range values {
-		values[i].name = transform(values[i].name)
+	for i, value := range values {
+		trimmedName := strings.TrimPrefix(value.name, trimPrefix)
+		values[i].name = transform(trimmedName)
 	}
 }
 
 // generate produces the String method for the named type.
-func (g *Generator) generate(typeName string, includeJSON, includeYAML, includeSQL bool, transformMethod string) {
+func (g *Generator) generate(typeName string, includeJSON, includeYAML, includeSQL bool, transformMethod string, trimPrefix string) {
 	values := make([]Value, 0, 100)
 	for _, file := range g.pkg.files {
 		// Set the state for this run of the walker.
@@ -317,7 +322,7 @@ func (g *Generator) generate(typeName string, includeJSON, includeYAML, includeS
 		log.Fatalf("no values defined for type %s", typeName)
 	}
 
-	g.transformValueNames(values, transformMethod)
+	g.transformValueNames(values, transformMethod, trimPrefix)
 
 	runs := splitIntoRuns(values)
 	// The decision of which pattern to use depends on the number of


### PR DESCRIPTION
This is a "first pass" at a pull request, so I haven't updated any documentation -- if it seems like a feature you'd like, and if the code seems reasonable, I can update the docs before you accept it.

We ran into a situation where we want enum values to be different from their names, to avoid collisions with other types -- e.g.:

    type Cat struct{}
    type Dog struct{}

    // go:generate enumer -trimPrefix=AnimalType
    type AnimalType int

    const (
        // These enums will read as "Cat" and "Dog", but their names
        // don't collide with the Cat and Dog types in the same package
        AnimalTypeCat AnimalType = iota
        AnimalTypeDog
    )

The "-trimPrefix" flag lets us use long names for the Go constants, but short names for the actual enum values.

Again, if you like this pull request in principle, let me know so I can add it to the Readme.