### PR TITLE
Comments for JSON and YAML marshaler methods

### DIFF
--- a/enumer.go
+++ b/enumer.go
@@ -5,7 +5,7 @@ import "fmt"
 // Arguments to format are:
 //	[1]: type name
 const stringValueToNameMap = `// %[1]sString retrieves an enum value from the enum constants string name.
-// Throws an error if the param is not part of the enum. 
+// Throws an error if the param is not part of the enum.
 func %[1]sString(s string) (%[1]s, error) {
 	if val, ok := _%[1]sNameToValueMap[s]; ok {
 		return val, nil
@@ -40,10 +40,12 @@ func (g *Generator) buildValueToNameMap(runs [][]Value, typeName string, runsThr
 // Arguments to format are:
 //	[1]: type name
 const jsonMethods = `
+// MarshalJSON implements the json.Marshaler interface for %[1]s
 func (i %[1]s) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.String())
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface for %[1]s
 func (i *%[1]s) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
@@ -63,10 +65,12 @@ func (g *Generator) buildJSONMethods(runs [][]Value, typeName string, runsThresh
 // Arguments to format are:
 //	[1]: type name
 const yamlMethods = `
+// MarshalYAML implements a YAML Marshaler interface for %[1]s
 func (i %[1]s) MarshalYAML() (interface{}, error) {
 	return i.String(), nil
 }
 
+// UnmarshalYAML implements a YAML Unmarshaler interface for %[1]s
 func (i *%[1]s) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {

--- a/golden_test.go
+++ b/golden_test.go
@@ -440,10 +440,12 @@ func PrimeString(s string) (Prime, error) {
 	return 0, fmt.Errorf("%s does not belong to Prime values", s)
 }
 
+// MarshalJSON implements the json.Marshaler interface for Prime
 func (i Prime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.String())
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface for Prime
 func (i *Prime) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
@@ -526,10 +528,12 @@ func PrimeString(s string) (Prime, error) {
 	return 0, fmt.Errorf("%s does not belong to Prime values", s)
 }
 
+// MarshalYAML implements a YAML Marshaler interface for Prime
 func (i Prime) MarshalYAML() (interface{}, error) {
 	return i.String(), nil
 }
 
+// UnmarshalYAML implements a YAML Unmarshaler interface for Prime
 func (i *Prime) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var s string
 	if err := unmarshal(&s); err != nil {
@@ -711,10 +715,12 @@ func PrimeString(s string) (Prime, error) {
 	return 0, fmt.Errorf("%s does not belong to Prime values", s)
 }
 
+// MarshalJSON implements the json.Marshaler interface for Prime
 func (i Prime) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.String())
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface for Prime
 func (i *Prime) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {


### PR DESCRIPTION
`go vet` will complain when an exported method is not properly
documented. This change adds comments to the generated `MarshalJSON`,
`UnmarshalJSON`, `MarshalYAML`, and `UnmarshalYAML` methods to satisfy
`go vet`.

As of go 1.10, the go test command now [automatically runs `go vet` on the
package being tested][1]. Complaints from `go vet` are treated like build
errors and prevent execution of the test. This means that generated code
that is not properly documented will prevent test execution.

[1]: https://golang.org/doc/go1.10#test-vet