### PR TITLE
Fix typo in generated comment for UnmarshalText

### DIFF
--- a/enumer.go
+++ b/enumer.go
@@ -119,7 +119,7 @@ func (i %[1]s) MarshalText() ([]byte, error) {
 	return []byte(i.String()), nil
 }
 
-// MarshalText implements the encoding.TextUnmarshaler interface for %[1]s
+// UnmarshalText implements the encoding.TextUnmarshaler interface for %[1]s
 func (i *%[1]s) UnmarshalText(text []byte) error {
 	var err error
 	*i, err = %[1]sString(string(text))

--- a/golden_test.go
+++ b/golden_test.go
@@ -660,7 +660,7 @@ func (i Prime) MarshalText() ([]byte, error) {
 	return []byte(i.String()), nil
 }
 
-// MarshalText implements the encoding.TextUnmarshaler interface for Prime
+// UnmarshalText implements the encoding.TextUnmarshaler interface for Prime
 func (i *Prime) UnmarshalText(text []byte) error {
 	var err error
 	*i, err = PrimeString(string(text))


### PR DESCRIPTION
Currently, the generated code starts with "// MarshalText" even though
the method is "UnmarshalText".