### PR TITLE
Add support for several new transformation options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ name := MyTypeValue.String() // name => "MyTypeValue"
 
 Sometimes you need to use some other string representation format than CamelCase (i.e. in JSON).
 
-To transform it from CamelCase to snake_case or kebab-case, you can use the `transform` flag.
-
 For example, the command `enumer -type=MyType -json -transform=snake` would generate the following string representation:
 
 ```go
@@ -128,13 +126,42 @@ for more information.
 There are four boolean flags: `json`, `text`, `yaml` and `sql`. You can use any combination of them (i.e. `enumer -type=Pill -json -text`),
 
 
-For enum string representation transformation the `transform` and `trimprefix` flags
+To transform the enum string representation the `transform` and `trimprefix` flags
 were added (i.e. `enumer -type=MyType -json -transform=snake`).
-Possible transform values are `snake` and `kebab` for transformation to snake_case and kebab-case accordingly.
+The possible transform values are:
+
+- lower - mytypevalue
+
+- upper - MYTYPEVALUE
+
+- json - myTypeValue
+
+- snake - my_type_value
+
+- snakeu - MY_TYPE_VALUE
+
+- kebab - my-type-value
+
+- kebabu - MY-TYPE-VALUE
+
 The default value for `transform` flag is `noop` which means no transformation will be performed.
 
 If a prefix is provided via the `trimprefix` flag, it will be trimmed from the start of each name (before
 it is transformed). If a name doesn't have the prefix it will be passed unchanged.
+
+The -ignorecase and -numeric flags allow more permissive conversions from a string to an
+enum value:
+
+- ignorecase
+
+  Ignores the case of the input string. This won't work if any of your enum names differ
+  only by case.
+
+- numeric
+
+  In addition to converting from a name string, the conversion will also handle an input string
+  that is a number matching the enum value. So the string "4" would translate to the enum that
+  has the value 4.
 
 ## Inspiring projects
 * [Stringer](https://godoc.org/golang.org/x/tools/cmd/stringer)

--- a/golden_test.go
+++ b/golden_test.go
@@ -1056,7 +1056,7 @@ func runGoldenTest(t *testing.T, test Golden, generateJSON, generateYAML, genera
 	if len(tokens) != 3 {
 		t.Fatalf("%s: need type declaration on first line", test.name)
 	}
-	g.generate(tokens[1], generateJSON, generateYAML, generateSQL, generateText, "noop", prefix)
+	g.generate(tokens[1], generateJSON, generateYAML, generateSQL, generateText, "noop", prefix, false, false, "")
 	got := string(g.format())
 	if got != test.output {
 		t.Errorf("%s: got\n====\n%s====\nexpected\n====%s", test.name, got, test.output)

--- a/stringer.go
+++ b/stringer.go
@@ -374,7 +374,7 @@ func (g *Generator) generate(typeName string, includeJSON, includeYAML, includeS
 	}
 
 	if includeJSON {
-		g.buildJSONMethods(runs, typeName, runsThreshold)
+		g.buildJSONMethods(runs, typeName, runsThreshold, numeric)
 	}
 	if includeText {
 		g.buildTextMethods(runs, typeName, runsThreshold)

--- a/stringer.go
+++ b/stringer.go
@@ -39,7 +39,7 @@ var (
 	ignoreCase      = flag.Bool("ignorecase", false, "if true, transforming from a string ignores case. Default: false")
 	numeric         = flag.Bool("numeric", false, "if true, transforming from a string allows input of numeric values. Default: false")
 	text            = flag.Bool("text", false, "if true, text marshaling methods will be generated. Default: false")
-	output          = flag.String("output", "", "output file name; default srcdir/<type>_enumer.go")
+	output          = flag.String("output", "", "output file name; default srcdir/<type>_string.go")
 	transformMethod = flag.String("transform", "noop", "enum item name transformation method. Default: noop")
 	trimPrefix      = flag.String("trimprefix", "", "transform each item name by removing a prefix. Default: \"\"")
 	empty           = flag.String("empty", "", "Use an empty string for this enum value. Default: \"\"")
@@ -120,7 +120,7 @@ func main() {
 	// Write to file.
 	outputName := *output
 	if outputName == "" {
-		baseName := fmt.Sprintf("%s_enumer.go", types[0])
+		baseName := fmt.Sprintf("%s_string.go", types[0])
 		outputName = filepath.Join(dir, strings.ToLower(baseName))
 	}
 	err := ioutil.WriteFile(outputName, src, 0644)


### PR DESCRIPTION
This change adds support for additional transformations of the name. The
new values are lower, upper, kebabu, and snakeu.

Options have been added to handle more permissive translation from a
string to a value. The -ignorecase option ignores case when comparing
the input string to the enum name. The -numeric option allows
translation of numbers in input strings in addition to the enum names.

Finally, an option has been added to specify a zero value enum which is
represented by an empty string. The empty string is used when generating
a string from a value, or when converting a string to a value.