### PR TITLE
Add support for BSON marshaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,13 @@ be almost meaningless or hard to trace or use by a human.
   * Method `IsA<Type>()`: returns true only if the current value is among the values of the enum. Useful for validations.
 * When the flag `json` is provided, two additional methods will be generated, `MarshalJSON()` and `UnmarshalJSON()`. These make
 the enum conform to the `json.Marshaler` and `json.Unmarshaler` interfaces. Very useful to use it in JSON APIs.
+* When the flag `bson` is provided, two additional methods will be generated, `MarshalBSONValue()` and `UnmarshalBSONValue()`. These make
+the enum conform to the `go.mongodb.org/mongo-driver/bson.ValueMarshaler` and `go.mongodb.org/mongo-driver/bson.ValueUnmarshaler` interfaces. 
+This can be used when inserting and retrieving enums from MongoDB.
 * When the flag `text` is provided, two additional methods will be generated, `MarshalText()` and `UnmarshalText()`. These make
 the enum conform to the `encoding.TextMarshaler` and `encoding.TextUnmarshaler` interfaces. 
 **Note:** If you use your enum values as keys in a map and you encode the map as _JSON_, you need this flag set to true to properly
-convert the map keys to json (strings). If not, the numeric values will be used instead
+convert the map keys to json (strings). If not, the numeric values will be used instead.
 * When the flag `yaml` is provided, two additional methods will be generated, `MarshalYAML()` and `UnmarshalYAML()`. These make
 the enum conform to the `gopkg.in/yaml.v2.Marshaler` and `gopkg.in/yaml.v2.Unmarshaler` interfaces.
 * When the flag `sql` is provided, the methods for implementing the Scanner and Valuer interfaces will be also generated.
@@ -134,7 +137,7 @@ name := MyTypeValue.String() // name => "my_type_value"
 The usage of Enumer is the same as Stringer, so you can refer to the [Stringer docs](https://godoc.org/golang.org/x/tools/cmd/stringer)
 for more information.
 
-There are four boolean flags: `json`, `text`, `yaml` and `sql`. You can use any combination of them (i.e. `enumer -type=Pill -json -text`),
+There are five boolean flags: `json`, `bson`, `text`, `yaml` and `sql`. You can use any combination of them (i.e. `enumer -type=Pill -json -text`),
 
 
 For enum string representation transformation the `transform` and `trimprefix` flags

--- a/enumer.go
+++ b/enumer.go
@@ -155,3 +155,24 @@ func (i *%[1]s) UnmarshalYAML(unmarshal func(interface{}) error) error {
 func (g *Generator) buildYAMLMethods(runs [][]Value, typeName string, runsThreshold int) {
 	g.Printf(yamlMethods, typeName)
 }
+
+// Arguments to format are:
+//	[1]: type name
+const bsonMethods = `
+// MarshalBSONValue implements the bson.ValueMarshaler interface for %[1]s
+func (i %[1]s) MarshalBSONValue() (bsontype.Type, []byte, error) {
+	return bsontype.String, bsoncore.AppendString(nil, i.String()), nil
+}
+
+// UnmarshalBSONValue implements the bson.ValueUnmarshaler interface for %[1]s
+func (i *%[1]s) UnmarshalBSONValue(t bsontype.Type, src []byte) error {
+	str, _, _ := bsoncore.ReadString(src)
+	var err error
+	*i, err = %[1]sString(str)
+	return err
+}
+`
+
+func (g *Generator) buildBSONMethods(runs [][]Value, typeName string, runsThreshold int) {
+	g.Printf(bsonMethods, typeName)
+}


### PR DESCRIPTION
Add the funcs MarshalBSONValue and UnmarshalBSONValue, allowing enums to be inserted and retrieved from MongoDB which uses a BSON store.